### PR TITLE
feat: add Podman support with Docker/Podman runtime auto-detection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
         max-size: "10m"
         max-file: "3"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${CONTAINER_SOCKET}:/var/run/docker.sock
       - /etc/timezone:/etc/timezone:ro
     environment:
       - DOCKER_API_VERSION=1.44

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 echo 'Loading the default files...'
+# Optional: pin the container runtime to "podman" or "docker".
+# Leave unset to auto-detect (Podman preferred when both are present).
+# export CONTAINER_RUNTIME=""
 export Afg_File="SmartSaw_DC_HA.afg"
 export Json_File="SmartSaw_alarms.json"
 export Device_File="SmartSaw_DC_HA.xml"

--- a/lib.sh
+++ b/lib.sh
@@ -4,6 +4,53 @@
 # Shared library — sourced by ssInstall.sh and ssUpgrade.sh
 ############################################################
 
+# Detect the container runtime and set CONTAINER_RUNTIME, COMPOSE_CMD,
+# and CONTAINER_SOCKET. Honors a CONTAINER_RUNTIME already set in env.sh
+# so operators can pin one explicitly. Otherwise prefers Podman over Docker.
+detect_container_runtime() {
+    if [[ -n "${CONTAINER_RUNTIME:-}" ]]; then
+        # Operator pinned a runtime — install it if not present.
+        if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
+            if [[ "$CONTAINER_RUNTIME" != "podman" && "$CONTAINER_RUNTIME" != "docker" ]]; then
+                echo "ERROR: CONTAINER_RUNTIME is set to '$CONTAINER_RUNTIME' which is not a supported value (podman or docker)." >&2
+                exit 1
+            fi
+            echo "CONTAINER_RUNTIME pinned to '$CONTAINER_RUNTIME' but not found. Installing..."
+            apt update --fix-missing && apt install -y "$CONTAINER_RUNTIME" --fix-missing
+            apt clean
+            if ! command -v "$CONTAINER_RUNTIME" &> /dev/null; then
+                echo "ERROR: Failed to install $CONTAINER_RUNTIME." >&2
+                exit 1
+            fi
+        fi
+    elif command -v podman &> /dev/null; then
+        CONTAINER_RUNTIME=podman
+    elif command -v docker &> /dev/null; then
+        CONTAINER_RUNTIME=docker
+    else
+        echo "Neither podman nor docker found. Installing podman..."
+        apt update --fix-missing && apt install -y podman --fix-missing
+        apt clean
+        if ! command -v podman &> /dev/null; then
+            echo "ERROR: Failed to install podman. Please install a container runtime manually." >&2
+            exit 1
+        fi
+        CONTAINER_RUNTIME=podman
+    fi
+
+    if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
+        COMPOSE_CMD="podman compose"
+        CONTAINER_SOCKET="/run/podman/podman.sock"
+    else
+        COMPOSE_CMD="docker compose"
+        CONTAINER_SOCKET="/var/run/docker.sock"
+    fi
+
+    export CONTAINER_RUNTIME COMPOSE_CMD CONTAINER_SOCKET
+    echo "Container runtime: $CONTAINER_RUNTIME"
+}
+
+
 # Check if a systemd service exists.
 service_exists() {
     local n=$1

--- a/ssClean.sh
+++ b/ssClean.sh
@@ -2,6 +2,7 @@
 
 SCRIPT_DIR="$(dirname "$0")"
 source "$SCRIPT_DIR/lib.sh" || { echo "ERROR: lib.sh not found at $SCRIPT_DIR/lib.sh"; exit 1; }
+detect_container_runtime
 
 ############################################################
 # Help                                                     #
@@ -21,7 +22,7 @@ Help(){
     echo "-C                    Uninstall the HEMsaw devctl application"
     echo "-S                    Uninstall the HEMSaw MongoDB application"
     echo "-d                    Disable mongod, ods, and agent daemons"
-    echo "-D                    Uninstall Docker"
+    echo "-D                    Uninstall container runtime (Docker or Podman)"
     echo "-L Container_Name     Log repair for any NULL or ^@ char"
     echo "-h                    Print this Help."
 }
@@ -94,15 +95,12 @@ Uninstall_Mongodb(){
 }
 
 Uninstall_Docker(){
-    if $Use_Docker_Compose_v1; then
-        echo "Shutting down Docker containers using Docker Compose v1"
-        docker-compose down --volumes --remove-orphans
+    echo "Shutting down containers..."
+    $COMPOSE_CMD down --volumes --remove-orphans
 
-        echo "To fully uninstall Docker, run: 'apt purge -y docker-compose docker.io'"
+    if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
+        echo "To fully uninstall Podman, run: 'apt purge -y podman docker-compose-v2'"
     else
-        echo "Shutting down Docker containers using Docker Compose v2"
-        docker compose down --volumes --remove-orphans
-
         echo "To fully uninstall Docker, run: 'apt purge -y docker-compose-v2 docker.io'"
     fi
     echo "<<Done>>"
@@ -133,7 +131,7 @@ Uninstall_Daemon(){
 
 CleanLog(){
     # Get the log path for the specified container
-    log_path=$(docker inspect --format='{{.LogPath}}' "$container_name")
+    log_path=$($CONTAINER_RUNTIME inspect --format='{{.LogPath}}' "$container_name")
 
     # Check if the log path was successfully retrieved
     if [ -z "$log_path" ]; then
@@ -176,19 +174,7 @@ run_uninstall_devctl=false
 run_uninstall_mongodb=false
 run_uninstall_docker=false
 run_uninstall_daemon=false
-Use_Docker_Compose_v1=false
 clean_logs=false
-
-# Auto-detect Docker Compose version
-if docker compose version &> /dev/null; then
-    # Docker Compose v2 is available
-    Use_Docker_Compose_v1=false
-else
-    if command -v docker-compose &> /dev/null; then
-        # Docker Compose v1 is available
-        Use_Docker_Compose_v1=true
-    fi
-fi
 
 ############################################################
 # Process the input options. Add options as needed.        #
@@ -266,10 +252,9 @@ echo "uninstall MQTT Broker = "$run_uninstall_mqtt
 echo "uninstall ODS = "$run_uninstall_ods
 echo "uninstall Devctl = "$run_uninstall_devctl
 echo "uninstall Mongodb = "$run_uninstall_mongodb
-echo "uninstall Docker = "$run_uninstall_docker
+echo "uninstall container runtime = "$run_uninstall_docker
 echo "disable Systemctl Daemons = "$run_uninstall_daemon
-echo "Run Docker Compose V1 commands = " $Use_Docker_Compose_v1
-echo "Clean the docker log for container (" $container_name ") = " $clean_logs
+echo "Clean the container log for container (" $container_name ") = " $clean_logs
 
 echo ""
 if $clean_logs; then

--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -2,6 +2,7 @@
 
 SCRIPT_DIR="$(dirname "$0")"
 source "$SCRIPT_DIR/lib.sh" || { echo "ERROR: lib.sh not found at $SCRIPT_DIR/lib.sh"; exit 1; }
+detect_container_runtime
 acquire_upgrade_lock
 
 ############################################################
@@ -278,14 +279,22 @@ if [[ -f "$SCRIPT_DIR/env.sh" ]]; then
     fi
 fi
 
-# Require Docker Compose v2 - install if not present
+# Require Docker Compose v2 - install if not present (used by both docker and podman compose)
 if ! docker compose version &> /dev/null; then
     echo "Docker Compose v2 not found, installing docker-compose-v2..."
     apt update --fix-missing && apt install -y docker-compose-v2 --fix-missing
     apt clean
     if ! docker compose version &> /dev/null; then
         echo "ERROR: Failed to install docker-compose-v2."
-        echo "Please install it manually: apt install docker-compose-v2 on Ubuntu"
+        exit 1
+    fi
+fi
+
+# When using Podman, verify podman compose can find docker-compose-v2 as a provider
+if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
+    if ! podman compose version &> /dev/null; then
+        echo "ERROR: podman compose failed even though podman and docker-compose-v2 are both installed."
+        echo "Ensure Podman v4.7+ is installed and docker-compose-v2 is accessible in PATH."
         exit 1
     fi
 fi
@@ -329,9 +338,9 @@ if [[ ! -f ./devctl/config/"$DevCTL_File" ]]; then
     exit 1
 fi
 
-if service_exists docker; then
-    echo "Shutting down any old Docker containers"
-    docker compose down
+if command -v "$CONTAINER_RUNTIME" &> /dev/null; then
+    echo "Shutting down any old containers"
+    $COMPOSE_CMD down
 fi
 echo ""
 
@@ -342,9 +351,9 @@ InstallDevctl
 InstallMongodb
 echo ""
 
-echo "Starting up the Docker image"
-docker compose up --remove-orphans -d
-docker compose logs
+echo "Starting up the containers"
+$COMPOSE_CMD up --remove-orphans -d
+$COMPOSE_CMD logs
 
 echo ""
 /etc/mongodb/venv/bin/python /etc/mongodb/data/jobs_parts_init.py
@@ -353,4 +362,4 @@ echo ""
 
 echo ""
 echo "Check to verify containers are running:"
-docker ps
+$CONTAINER_RUNTIME ps

--- a/ssStatus.sh
+++ b/ssStatus.sh
@@ -1,7 +1,11 @@
-#!/bin/sh
+#!/bin/bash
+
+SCRIPT_DIR="$(dirname "$0")"
+source "$SCRIPT_DIR/lib.sh" || { echo "ERROR: lib.sh not found at $SCRIPT_DIR/lib.sh"; exit 1; }
+detect_container_runtime
 
 if [[ $(id -u) -ne 0 ]] ; then echo "Please run bash ssStatus.sh as sudo" ; exit 1 ; fi
 
-echo "Docker container status for HEMSaw MTConnect-SmartAdapter, MTConnect Agent, Mosquitto, ODS, Devctl, Mongodb and Watchtower..."
-docker ps
+echo "Container status for HEMSaw MTConnect-SmartAdapter, MTConnect Agent, Mosquitto, ODS, Devctl, Mongodb and Watchtower..."
+$CONTAINER_RUNTIME ps
 echo "<<DONE>>"

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -2,6 +2,7 @@
 
 SCRIPT_DIR="$(dirname "$0")"
 source "$SCRIPT_DIR/lib.sh" || { echo "ERROR: lib.sh not found at $SCRIPT_DIR/lib.sh"; exit 1; }
+detect_container_runtime
 
 ############################################################
 # Help                                                     #
@@ -39,20 +40,20 @@ Help(){
 ############################################################
 # Function to install and run Docker
 RunDocker(){
-    if service_exists docker; then
-        echo "Shutting down any old Docker containers"
-        docker compose down
+    if command -v "$CONTAINER_RUNTIME" &> /dev/null; then
+        echo "Shutting down any old containers"
+        $COMPOSE_CMD down
 
-        echo "Pulling latest Docker images..."
-        docker compose pull
+        echo "Pulling latest images..."
+        $COMPOSE_CMD pull
 
-        echo "Starting up the Docker containers..."
-        docker compose up --remove-orphans -d
+        echo "Starting up the containers..."
+        $COMPOSE_CMD up --remove-orphans -d
     fi
 
     # Display logs
     echo "Displaying container logs..."
-    docker compose logs mtc_adapter mtc_agent mosquitto ods devctl mongodb
+    $COMPOSE_CMD logs mtc_adapter mtc_agent mosquitto ods devctl mongodb
 }
 
 
@@ -454,13 +455,22 @@ if [[ "$run_full_update" == true ]] && [[ "${Use_MQTT_Bridge:-false}" == "true" 
     run_update_mqtt_bridge=true
 fi
 
-# Require Docker Compose v2 - install if not present
+# Require Docker Compose v2 - install if not present (used by both docker and podman compose)
 if ! docker compose version &> /dev/null; then
     echo "Docker Compose v2 not found, installing docker-compose-v2..."
     apt update --fix-missing && apt install -y docker-compose-v2 --fix-missing
     apt clean
     if ! docker compose version &> /dev/null; then
-        echo "ERROR: Failed to install docker-compose-v2. Please install it manually: apt install docker-compose-v2"
+        echo "ERROR: Failed to install docker-compose-v2."
+        exit 1
+    fi
+fi
+
+# When using Podman, verify podman compose can find docker-compose-v2 as a provider
+if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
+    if ! podman compose version &> /dev/null; then
+        echo "ERROR: podman compose failed even though podman and docker-compose-v2 are both installed."
+        echo "Ensure Podman v4.7+ is installed and docker-compose-v2 is accessible in PATH."
         exit 1
     fi
 fi
@@ -538,10 +548,10 @@ if [[ ! -f ./devctl/config/$DevCTL_File ]]; then
     exit 1
 fi
 
-# Shutdown any old Docker containers before updating files
-if service_exists docker; then
-    echo "Shutting down any old Docker containers"
-    docker compose down
+# Shutdown any old containers before updating files
+if command -v "$CONTAINER_RUNTIME" &> /dev/null; then
+    echo "Shutting down any old containers"
+    $COMPOSE_CMD down
 fi
 echo ""
 
@@ -616,17 +626,17 @@ echo "Check to verify containers are running:"
 # created by this project's compose stack. Safer if other Docker projects
 # are ever added to the host.
 echo "Pruning dangling images from this project..."
-if docker image prune --filter "dangling=true" --force > /dev/null; then
+if $CONTAINER_RUNTIME image prune --filter "dangling=true" --force > /dev/null; then
     echo "Dangling image pruning completed successfully"
 else
     echo "No dangling images to prune or pruning failed"
 fi
 
-echo "Pruning unused Docker volumes..."
-if docker volume prune --force > /dev/null; then
+echo "Pruning unused volumes..."
+if $CONTAINER_RUNTIME volume prune --force > /dev/null; then
     echo "Volume pruning completed successfully"
 else
     echo "No volumes to prune or pruning failed"
 fi
 
-docker ps
+$CONTAINER_RUNTIME ps


### PR DESCRIPTION
- Add detect_container_runtime() to lib.sh: prefers Podman over Docker,
  auto-installs the runtime and docker-compose-v2 if missing, exports
  CONTAINER_RUNTIME, COMPOSE_CMD, and CONTAINER_SOCKET
- Replace all hardcoded docker/docker-compose calls in ssInstall.sh,
  ssUpgrade.sh, ssClean.sh, and ssStatus.sh with runtime variables
- Add podman compose verification step: fails if podman compose cannot
  find docker-compose-v2 as a provider after both are installed
- Update docker-compose.yml Watchtower socket to use ${CONTAINER_SOCKET}
  so Podman socket path is set dynamically at runtime
- Add optional CONTAINER_RUNTIME pin to env.sh for operator overrides