### PR TITLE
fix: let watchtower auto-negotiate the Docker API version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /etc/timezone:/etc/timezone:ro
     environment:
-      - DOCKER_API_VERSION=1.44
       - WATCHTOWER_CLEANUP=true
       - WATCHTOWER_LABEL_ENABLE=true
       - WATCHTOWER_REMOVE_VOLUMES=true


### PR DESCRIPTION
Pinning DOCKER_API_VERSION breaks on hosts whose daemon reports a
different API version than the one hardcoded, requiring manual edits
(1.44 -> 1.43) to keep working. Leaving it unset lets the Docker
client negotiate the correct version with the daemon automatically.