### PR TITLE
fix: disable TLS listener cert paths by default in mosquitto.conf

### DIFF
--- a/mqtt/config/mosquitto.conf
+++ b/mqtt/config/mosquitto.conf
@@ -11,11 +11,11 @@ protocol mqtt
 # TLS listener on 8883
 listener 8883 0.0.0.0
 protocol mqtt
-certfile /mosquitto/certs/server.crt
-keyfile  /mosquitto/certs/server.key
+# certfile /mosquitto/certs/server.crt
+# keyfile  /mosquitto/certs/server.key
 
 # If using a private CA, include the CA so clients can build a full chain (optional for server auth, required for mTLS)
-cafile /mosquitto/certs/ca.crt
+# cafile /mosquitto/certs/ca.crt
 
 # For mutual TLS (client cert auth), uncomment:
 # require_certificate true


### PR DESCRIPTION
No cert/key files exist at these paths until TLS is actually
configured, so mosquitto would fail to start the 8883 listener out
of the box. Comment them out until an operator provisions certs.